### PR TITLE
Demo App -> Use BOM

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -70,9 +70,12 @@ dependencies {
 
     coreLibraryDesugaring(libs.desugarJdkLibs)
 
-    implementation("io.opentelemetry.android:instrumentation-compose-click")
+    implementation(platform("io.opentelemetry.android:opentelemetry-android-bom:0.15.0-alpha"))
+    implementation("io.opentelemetry.android.instrumentation:compose-click")
     implementation("io.opentelemetry.android:android-agent")    //parent dir
-    implementation("io.opentelemetry.android:instrumentation-sessions")
+    implementation("io.opentelemetry.android.instrumentation:sessions")
+    implementation(libs.opentelemetry.exporter.otlp)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -82,7 +85,6 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
 
-    implementation(libs.opentelemetry.exporter.otlp)
 
     testImplementation(libs.bundles.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/demo-app/settings.gradle.kts
+++ b/demo-app/settings.gradle.kts
@@ -19,14 +19,3 @@ dependencyResolutionManagement {
         google()
     }
 }
-
-includeBuild("..") {
-    dependencySubstitution {
-        substitute(module("io.opentelemetry.android:instrumentation-compose-click"))
-            .using(project(":instrumentation:compose:click"))
-        substitute(module("io.opentelemetry.android:android-agent"))
-            .using(project(":android-agent"))
-        substitute(module("io.opentelemetry.android:instrumentation-sessions"))
-            .using(project(":instrumentation:sessions"))
-    }
-}


### PR DESCRIPTION
This shows you how to modify the demo app to use the bom dependency instead of the included project dirs.