### PR TITLE
Generate event semantic attributes

### DIFF
--- a/semconv/templates/registry/kotlin/weaver.yaml
+++ b/semconv/templates/registry/kotlin/weaver.yaml
@@ -12,11 +12,32 @@ templates:
     file_name: "io/opentelemetry/android/semconv/events/OpenTelemetryEvent.kt"
   - pattern: kotlin_semconv_template.kt.j2
     filter: >
-      semconv_grouped_attributes({
-        "exclude_stability": []
-      })
-      | map({ root_namespace: .root_namespace,
-              attributes: (.attributes | unique_by(.name)),
+      (
+        (
+          semconv_grouped_attributes({
+            "exclude_stability": []
+          })
+          | map({ root_namespace: .root_namespace,
+                  attributes: (.attributes | unique_by(.name)),
+                  excluded_attributes: [] })
+        )
+        +
+        (
+          semconv_signal("event"; {
+            "exclude_stability": []
+          })
+          | map(.attributes // [])
+          | flatten
+          | unique_by(.name)
+          | group_by(.name | split(".")[0])
+          | map({ root_namespace: (.[0].name | split(".")[0]),
+                  attributes: .,
+                  excluded_attributes: [] })
+        )
+      )
+      | group_by(.root_namespace)
+      | map({ root_namespace: .[0].root_namespace,
+              attributes: (map(.attributes) | flatten | unique_by(.name)),
               excluded_attributes: [] })
     application_mode: each
     file_name: "io/opentelemetry/android/semconv/{{ctx.root_namespace | pascal_case}}Attributes.kt"


### PR DESCRIPTION
This is a stacked PR on top of #1948. 

So in the effort to move away from the kotlin generated semconv, I noticed that tests started hard coding some of the string literals because the dependency was gone. I don't love that and I think it's too fragile. 

So instead, we can look at the events and see what attributes they reference, and bring those attributes into our generated attributes objects. Originally I had created these as constants on the Event classes themselves, but it felt awkward. This approach here IMO keeps a cleaner separation between the Event classes and the Attribute object definitions.

The follow-up (stacked) PR will then use these constants from the Event classes and from the tests.